### PR TITLE
Remove redundant collision checks

### DIFF
--- a/bullet.c
+++ b/bullet.c
@@ -12,9 +12,6 @@ static int bullet_collision_right(bullet_t *bullet, tile_t map[TILEMAP_WIDTH * T
             if(map[idx].is_inside(&map[idx], bullet->tile->x+10, bullet->tile->y+1)) {
                 return 1;
             }
-            if (map[idx].is_inside(&map[idx], bullet->tile->x+10, bullet->tile->y+1)) {
-                return 1;
-            }
         }
     }
     return 0;
@@ -24,9 +21,6 @@ static int bullet_collision_left(bullet_t *bullet, tile_t map[TILEMAP_WIDTH * TI
     int idx = 0;
     for (idx = 0; idx < TILEMAP_WIDTH * TILEMAP_HEIGHT; idx++) {
         if (map[idx].sprites[0] != 0 && map[idx].mod == BRICK) {
-            if (map[idx].is_inside(&map[idx], bullet->tile->x - 2, bullet->tile->y + 1)) {
-                return 1;
-            }
             if (map[idx].is_inside(&map[idx], bullet->tile->x - 2, bullet->tile->y + 1)) {
                 return 1;
             }


### PR DESCRIPTION
Seems bullet_collisiion_right/left() functs were checking for the same collision conditions twice, please lmk if I'm missing something.

---

Btw, I'm a fan of Dave too and I really liked the repo, thanks for all the work!

If you don't mind, I may create a Rust port of this repo by preserving the current commit history and building on top of it module by module. Tbh, I already created a private fork and but the work is still in-progress and I'm not yet sure if I'll give up working on it or not :)