### PR TITLE
Free allocated resources

### DIFF
--- a/bullet.c
+++ b/bullet.c
@@ -63,6 +63,15 @@ static int bullet_get_sprite(tile_t *tile) {
     }
 }
 
+void bullet_destroy(bullet_t *bullet) {
+    if (!bullet) return;
+
+    if (bullet->tile) {
+        free(bullet->tile);
+    }
+    free(bullet);
+}
+
 bullet_t* bullet_create_internal(int x, int y, int speed) {
     bullet_t *bullet = malloc(sizeof(bullet_t));
     bullet->speed_x = speed;

--- a/bullet.c
+++ b/bullet.c
@@ -75,6 +75,7 @@ void bullet_destroy(bullet_t *bullet) {
 bullet_t* bullet_create_internal(int x, int y, int speed) {
     bullet_t *bullet = malloc(sizeof(bullet_t));
     bullet->speed_x = speed;
+    bullet->state = 0;
     bullet->steps = 0;
     bullet->tick = &bullet_tick;
     bullet->is_dead = &bullet_is_dead;

--- a/dave.c
+++ b/dave.c
@@ -775,6 +775,15 @@ static int dave_get_sprite(tile_t *tile) {
     return sprite;
 }
 
+void dave_destroy(dave_t *dave) {
+    if (!dave) return;
+
+    if (dave->tile) {
+        free(dave->tile);
+    }
+    free(dave);
+}
+
 dave_t* dave_create(soundfx_t *sfx, int x, int y) {
     dave_t *dave = malloc(sizeof(dave_t));
     dave->sfx = sfx;

--- a/game.c
+++ b/game.c
@@ -282,6 +282,10 @@ void init_game(game_context_t *game) {
     tile_create_top_separator(&game->top_separator, 0, 11);
     tile_create_grail_banner(&game->grail_banner, 70, 183);
     tile_create_gun_banner(&game->gun_banner, 240, 170);
+
+    for (int i = 0; i < MAX_MONSTERS; i++) {
+        game->monsters[i] = NULL;
+    }
 }
 
 void get_keys(keys_state_t* state) {
@@ -452,6 +456,7 @@ void start_intro() {
 
 void clear_monsters(game_context_t *game) {
     for (int i = 0; i < MAX_MONSTERS; i++) {
+        monster_destroy(game->monsters[i]);
         game->monsters[i] = NULL;
     }
 }
@@ -566,6 +571,7 @@ void game_do_plasmas(game_context_t *game, tile_t *map, keys_state_t *keys) {
         if (game->monsters[i] != NULL) {
             if (game->monsters[i]->plasma != NULL) {
                 if (game->monsters[i]->plasma->is_dead(game->monsters[i]->plasma)) {
+                    plasma_destroy(game->monsters[i]->plasma);
                     game->monsters[i]->plasma = NULL;
                 } else {
                     game->monsters[i]->plasma->tick(game->monsters[i]->plasma, map, (game->scroll_offset * 16) - 80, (game->scroll_offset * 16) + 400);
@@ -580,6 +586,7 @@ void game_do_bullets(game_context_t *game, tile_t *map, keys_state_t *keys) {
         game->bullet->tick(game->bullet, map, (game->scroll_offset * 16), (game->scroll_offset * 16) + 320);
 
         if (game->bullet->is_dead(game->bullet)) {
+            bullet_destroy(game->bullet);
             game->bullet = NULL;
         }
     } else {
@@ -837,6 +844,7 @@ int game_level(game_context_t *game, tile_t *map, keys_state_t *keys) {
             if (game->bullet != NULL) {
                 if (collision_detect(game->bullet->tile, game->monsters[idx]->tile)) {
                     if (game->monsters[idx]->on_fire != 1) {
+                        bullet_destroy(game->bullet);
                         game->bullet = NULL;
                         game->monsters[idx]->on_fire = 1;
                         g_soundfx->stop(g_soundfx);
@@ -860,6 +868,7 @@ int game_level(game_context_t *game, tile_t *map, keys_state_t *keys) {
         if (game->monsters[idx] != NULL) {
             if (game->monsters[idx]->plasma != NULL) {
                 if (collision_detect(game->dave->tile, game->monsters[idx]->plasma->tile)) {
+                    plasma_destroy(game->monsters[idx]->plasma);
                     game->monsters[idx]->plasma = NULL;
                     game->dave->on_fire = 1;
                     g_soundfx->stop(g_soundfx);
@@ -1028,6 +1037,12 @@ int game_level_load(game_context_t *game, tile_t *map, char *file) {
     return 0;
 }
 
+static void clear_gameloop(game_context_t *game) {
+    clear_monsters(game);
+    dave_destroy(game->dave);
+    bullet_destroy(game->bullet);
+}
+
 int gameloop(int starting_level) {
     game_context_t* game;
     tile_t map[TILEMAP_WIDTH * TILEMAP_HEIGHT];
@@ -1107,11 +1122,13 @@ int gameloop(int starting_level) {
 
         } else if (state == G_STATE_GAMEOVER) {
             SDL_UnlockTexture(g_texture);
+            clear_gameloop(game);
             free(game);
             return 2;
 
         } else if (state == G_STATE_QUIT_NOW) {
             SDL_UnlockTexture(g_texture);
+            clear_gameloop(game);
             free(game);
             return 1;
         }

--- a/include/bullet.h
+++ b/include/bullet.h
@@ -19,6 +19,7 @@ typedef struct bullet_struct {
     int (*is_dead)(struct bullet_struct *bullet);
 } bullet_t;
 
+void bullet_destroy(bullet_t *bullet);
 bullet_t* bullet_create_right(int x, int y);
 bullet_t* bullet_create_left(int x, int y);
 

--- a/include/dave.h
+++ b/include/dave.h
@@ -72,6 +72,7 @@ typedef struct dave_struct {
     int (*is_dead)(struct dave_struct *dave);
 } dave_t;
 
+void dave_destroy(dave_t *dave);
 dave_t* dave_create(soundfx_t *sfx, int x, int y);
 void dave_update_keys(dave_t *dave, int left, int right, int jump, int down, int jetpack);
 

--- a/include/monster.h
+++ b/include/monster.h
@@ -31,6 +31,7 @@ typedef struct monster_struct {
     int (*is_alive)(struct monster_struct *monster);
 } monster_t;
 
+void monster_destroy(monster_t *monster);
 monster_t* monster_create(int x, int y, int w, int h);
 monster_t* monster_create_sun(int x, int y);
 monster_t* monster_create_spider(int x, int y);

--- a/include/plasma.h
+++ b/include/plasma.h
@@ -20,6 +20,7 @@ typedef struct plasma_struct {
     int (*get_sprite)(struct plasma_struct *plasma);
 } plasma_t;
 
+void plasma_destroy(plasma_t *plasma);
 plasma_t* plasma_create_right(int x, int y);
 plasma_t* plasma_create_left(int x, int y);
 

--- a/monster.c
+++ b/monster.c
@@ -325,6 +325,19 @@ static int monster_is_alive(monster_t *monster) {
     return 0;
 }
 
+void monster_destroy(monster_t *monster) {
+    if (!monster) return;
+
+    if (monster->tile) {
+        free(monster->tile);
+    }
+
+    if (monster->plasma) {
+        plasma_destroy(monster->plasma);
+    }
+    free(monster);
+}
+
 monster_t* monster_create(int x, int y, int w, int h) {
     monster_t *monster = malloc(sizeof(monster_t));
 

--- a/plasma.c
+++ b/plasma.c
@@ -66,6 +66,15 @@ static int plasma_get_sprite(plasma_t *plasma) {
     return plasma->tile->get_sprite(plasma->tile);
 }
 
+void plasma_destroy(plasma_t *plasma) {
+    if (!plasma) return;
+
+    if (plasma->tile) {
+        free(plasma->tile);
+    }
+    free(plasma);
+}
+
 plasma_t* plasma_create_left(int x, int y) {
     plasma_t *plasma = malloc(sizeof(plasma_t));
 


### PR DESCRIPTION
Pointers to allocated resources are being dereferenced without deallocation.
This fixes the memory leaking by freeing the allocated resources before dereferencing the pointer, and upon exit of the gameloop.
